### PR TITLE
TWT-25 Change authorities creation from using JWT SCOPE to realm_acce…

### DIFF
--- a/api-gateway/src/main/java/apigateway/SecurityConfig.java
+++ b/api-gateway/src/main/java/apigateway/SecurityConfig.java
@@ -11,7 +11,7 @@ import org.springframework.security.web.server.SecurityWebFilterChain;
 public class SecurityConfig {
 
     @Bean
-    public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
+    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
 
         http.csrf().disable()
                 .authorizeExchange()

--- a/tweet-service/src/main/java/tweetservice/config/SecurityConfig.java
+++ b/tweet-service/src/main/java/tweetservice/config/SecurityConfig.java
@@ -2,12 +2,20 @@ package tweetservice.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
-import tweetservice.security.MockAuthenticationFilter;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Configuration
 @EnableMethodSecurity
@@ -20,13 +28,39 @@ public class SecurityConfig {
                 .authorizeHttpRequests()
                 .anyRequest().authenticated().and()
                 .oauth2ResourceServer()
-                .jwt();
+                .jwt()
+                .jwtAuthenticationConverter(customJwtAuthenticationConverter());
         //    .addFilterAfter(mockAuthenticationFilter(), BasicAuthenticationFilter.class)
         return http.build();
+    }
+
+    @Bean
+    public JwtAuthenticationConverter customJwtAuthenticationConverter() {
+        JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
+        converter.setJwtGrantedAuthoritiesConverter(new KeycloakJwtGrantedAuthoritiesConverter());
+        return converter;
     }
 
 //    @Bean
 //    public MockAuthenticationFilter mockAuthenticationFilter() {
 //        return new MockAuthenticationFilter();
 //    }
+
+    private class KeycloakJwtGrantedAuthoritiesConverter implements Converter<Jwt, Collection<GrantedAuthority>> {
+
+        @Override
+        public Collection<GrantedAuthority> convert(Jwt jwt) {
+            var realmAccess = (Map<String, List<String>>) jwt.getClaim("realm_access");
+
+            return realmAccess.get("roles").stream()
+                    .map(role -> "ROLE_" + role)
+                    .map(SimpleGrantedAuthority::new)
+                    .collect(Collectors.toList());
+        }
+
+        @Override
+        public <U> Converter<Jwt, U> andThen(Converter<? super Collection<GrantedAuthority>, ? extends U> after) {
+            return Converter.super.andThen(after);
+        }
+    }
 }


### PR DESCRIPTION
…ss roles

Previously, authorities were being created based on the SCOPE field of JWT. This commit changes that behavior and now uses the roles defined in realm_access.roles to create authorities. The creation of these authorities is done through the implementation of a custom JwtGrantedAuthoritiesConverter named KeycloakJwtGrantedAuthoritiesConverter.